### PR TITLE
修复jcenter仓库发布类库缺少reader仓库依赖

### DIFF
--- a/helper/build.gradle
+++ b/helper/build.gradle
@@ -30,7 +30,7 @@ android {
 
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
-    api project(':reader')
+    compile project(':reader')
     testImplementation 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
fix bug [Method threw 'java.lang.NoClassDefFoundError' exception](https://github.com/Tencent/VasDolly/issues/74#issuecomment-477911129)

或者需要更新接入文档为：
```
api 'com.leon.channel:helper:2.0.2'
implementation 'com.leon.channel:reader:2.0.2'
```